### PR TITLE
Fix `readLoc` function

### DIFF
--- a/src/page/debug.ts
+++ b/src/page/debug.ts
@@ -467,7 +467,7 @@ function readLoc({
     return;
   }
 
-  const loc = "config" in meta ? meta.config.loc : meta.loc;
+  const loc = meta.config ? meta.config.loc : meta.loc;
 
   return loc;
 }


### PR DESCRIPTION
Condition `"config" in meta` doesn't check property _content_.
Property could exist, but be undefined, causing error "reading .loc of undefined"